### PR TITLE
update the k8s ingress version to 1. required for k8s 1.21 and higher.

### DIFF
--- a/stable/chart-ad/templates/ingress.yaml
+++ b/stable/chart-ad/templates/ingress.yaml
@@ -3,7 +3,7 @@
 {{- $imageTag := .Values.image.tag -}}
 {{- $imageEnv := .Values.image.env -}}
 {{- $imageBranch := .Values.image.branch -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ printf "%s" .Release.Name | trunc 63 }}


### PR DESCRIPTION
[Fixes PLA-68](https://linear.app/daaily/issue/PLA-68/update-the-alb-ingress-controller-version). Small change to this repo. Required v1 to use ALB Ingress recent version on eks cluster 1.20 and higher.